### PR TITLE
Fix visit_VARCHAR method in IRISTypeCompiler to handle default length…

### DIFF
--- a/sqlalchemy_iris/base.py
+++ b/sqlalchemy_iris/base.py
@@ -742,6 +742,12 @@ class IRISTypeCompiler(compiler.GenericTypeCompiler):
     def visit_BIT(self, type_, **kw):
         return "BIT"
 
+    def visit_VARCHAR(self, type_, **kw):
+        # If length is not specified, use 50 as default in IRIS
+        if type_.length is None:
+            type_ = VARCHAR(50)
+        return "VARCHAR(%d)" % type_.length
+
     def visit_TEXT(self, type_, **kw):
         return "VARCHAR(65535)"
 


### PR DESCRIPTION
… in IRIS to fix it at 50 by default